### PR TITLE
Ability to SUBSCRIBE to events

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ killed.
 
 ```ruby
 block = Proc.new do |reply|
-  if(reply.change == 'title')
+  if reply.change == 'title'
     puts "title changed for window #{reply.container.name}"
   end
 end
@@ -114,6 +114,9 @@ end
 pid = i3.subscribe('window', block)
 pid.join
 ```
+
+It is recommended to use separate `Connection`s for each subscription,
+since replies to subscription events may be sent by i3 at any time.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,22 @@ Reply consists of a list of workspaces. Each workspace has some properties:
 
 ### Subscribe
 
-To be done (not implemented yet)
+Takes an [event](http://i3wm.org/docs/ipc.html#_available_events) and
+a Proc object. The Proc object will be called with i3's response
+whenever i3 generates the specified event. `subscribe` returns a
+Thread; the block will execute in this thread until the thread is
+killed.
+
+```ruby
+block = Proc.new do |reply|
+  if(reply.change == 'title')
+    puts "title changed for window #{reply.container.name}"
+  end
+end
+
+pid = i3.subscribe('window', block)
+pid.join
+```
 
 ### Outputs
 

--- a/lib/i3ipc/connection.rb
+++ b/lib/i3ipc/connection.rb
@@ -55,7 +55,7 @@ module I3Ipc
       @protocol.send(2, [event])
 
       reply = Reply.parse(@protocol.receive 2)
-      raise WrongEvent.new(event) unless reply["success"]
+      raise WrongEvent.new(event) unless reply.success?
 
       pid = Thread.new do
         while true

--- a/lib/i3ipc/connection.rb
+++ b/lib/i3ipc/connection.rb
@@ -2,6 +2,18 @@ require 'i3ipc/protocol'
 require 'i3ipc/reply'
 
 module I3Ipc
+  # Throws when subscribing to an invalid event. Valid events are
+  # listed in function event_number().
+  class WrongEvent < RuntimeError
+    def initialize(event_name)
+      @event_name = event_name
+    end
+
+    def message
+      %Q{Tried to subscribe to invalid event type '#{@event_name}'}
+    end
+  end
+
   # Entry point for communication with i3-ipc.
   # Able to send/receive messages and convert
   # responses.
@@ -36,6 +48,23 @@ module I3Ipc
       reply_for(1)
     end
 
+    def subscribe(event, block)
+      event_number = event_number(event)
+
+      # Send subscription request
+      @protocol.send(2, [event])
+      Reply.parse(@protocol.receive 2)
+
+      pid = Thread.new do
+        while true
+          reply = Reply.parse(@protocol.receive_event event_number)
+          block.call(reply)
+        end
+      end
+
+      pid
+    end
+
     def outputs
       reply_for(3)
     end
@@ -58,9 +87,23 @@ module I3Ipc
 
     private
 
-    def reply_for(type, message = nil)
+    def reply_for(type, message = nil, events=nil)
       @protocol.send(type, message)
+
       Reply.parse(@protocol.receive type)
     end
+
+    def event_number(event)
+      case event
+      when 'workspace'         then 0
+      when 'output'            then 1
+      when 'mode'              then 2
+      when 'window'            then 3
+      when 'barconfig_update'  then 4
+      when 'binding'           then 5
+      else raise WrongEvent.new(event)
+      end
+    end
+
   end
 end

--- a/lib/i3ipc/connection.rb
+++ b/lib/i3ipc/connection.rb
@@ -53,7 +53,9 @@ module I3Ipc
 
       # Send subscription request
       @protocol.send(2, [event])
-      Reply.parse(@protocol.receive 2)
+
+      reply = Reply.parse(@protocol.receive 2)
+      raise WrongEvent.new(event) unless reply["success"]
 
       pid = Thread.new do
         while true


### PR DESCRIPTION
This commit adds the subscribe method to Connection. Clients can
provide a Proc to be executed whenever i3 emits the event of interest.
