### PR TITLE
Add support for Sway

### DIFF
--- a/lib/i3ipc/protocol.rb
+++ b/lib/i3ipc/protocol.rb
@@ -150,8 +150,15 @@ module I3Ipc
     end
 
     def get_socketpath
-      path = `i3 --get-socketpath`.chomp!
-      raise 'Unable to get i3 socketpath' unless path
+      cmd = if system('i3 --version')
+        'i3'
+      elsif system('sway --version')
+        'sway'
+      else
+        raise 'Unable to find i3 compatible window manager'
+      end
+      path = `#{cmd} --get-socketpath`.chomp!
+      raise 'Unable to get i3 compatible socketpath' unless path
       path
     end
 

--- a/lib/i3ipc/version.rb
+++ b/lib/i3ipc/version.rb
@@ -1,3 +1,3 @@
 module I3ipc
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/lib/i3ipc/version.rb
+++ b/lib/i3ipc/version.rb
@@ -1,3 +1,3 @@
 module I3ipc
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
The only way to make it work with Sway is to initialize the protocol manually like this:
```
proto = I3Ipc::Protocol.new `sway --get-socketpath`.chomp
sway = I3Ipc::Connection.new proto
```
This change make it work without manually initializing the protocol.