### PR TITLE
Use I3SOCK environment variable for determining socket path

### DIFF
--- a/lib/i3ipc/protocol.rb
+++ b/lib/i3ipc/protocol.rb
@@ -150,16 +150,21 @@ module I3Ipc
     end
 
     def get_socketpath
-      cmd = if system('i3 --version')
-        'i3'
-      elsif system('sway --version')
-        'sway'
+      if !ENV['I3SOCK'].nil?
+        ENV['I3SOCK']
       else
-        raise 'Unable to find i3 compatible window manager'
+        cmd = if system('i3 --version')
+          'i3'
+        elsif system('sway --version')
+          'sway'
+        else
+          raise 'Unable to find i3 compatible window manager'
+        end
+
+        path = `#{cmd} --get-socketpath`.chomp!
+        raise 'Unable to get i3 compatible socketpath' unless path
+        path
       end
-      path = `#{cmd} --get-socketpath`.chomp!
-      raise 'Unable to get i3 compatible socketpath' unless path
-      path
     end
 
     def check_connected

--- a/lib/i3ipc/version.rb
+++ b/lib/i3ipc/version.rb
@@ -1,3 +1,3 @@
 module I3ipc
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
I attempted to use this system and noticed it spat out a version line on every connection initialization. I noticed that by default it only checks `i3 --version` and `sway --version` to determine what window manager/compositor is available.

However, both provide the environment variable `I3SOCK` for this purpose. While sway also provides `SWAYSOCK`, it kept `I3SOCK` for backwards compatibility purposes. This PR introduces a check for that environment variable first, before falling back on the existing testing method.